### PR TITLE
Fixed function name in generated script to escape characters when needed

### DIFF
--- a/coffee/lib/funcster.coffee
+++ b/coffee/lib/funcster.coffee
@@ -88,7 +88,7 @@ funcster =
   # Builds a text/javascript representation of a collection of functions.
   _generateModuleScript: (serializedFunctions) ->
     entries = []
-    entries.push("#{name}: #{body}") for name, body of serializedFunctions
+    entries.push("#{JSON.stringify(name)}: #{body}") for name, body of serializedFunctions
     entries = entries.join(',')
     "module.exports=(function(module,exports){return{#{entries}};})();"
 

--- a/coffee/test/funcster.test.coffee
+++ b/coffee/test/funcster.test.coffee
@@ -106,9 +106,10 @@ describe 'funcster module', () ->
       functions =
         'func_a': 'function(arg) { return arg; }'
         'func_b': 'function(arg) { return [ arg ]; }'
+        'complicated -" *$@ name': 'function(arg) { return arg; }'
 
       script = funcster._generateModuleScript(functions)
-      assert.equal script, 'module.exports=(function(module,exports){return{func_a: function(arg) { return arg; },func_b: function(arg) { return [ arg ]; }};})();'
+      assert.equal script, 'module.exports=(function(module,exports){return{"func_a": function(arg) { return arg; },"func_b": function(arg) { return [ arg ]; },"complicated -\\" *$@ name": function(arg) { return arg; }};})();'
 
   describe '_rerequire', () ->
 

--- a/js/lib/funcster.js
+++ b/js/lib/funcster.js
@@ -85,7 +85,7 @@
       entries = [];
       for (name in serializedFunctions) {
         body = serializedFunctions[name];
-        entries.push("" + name + ": " + body);
+        entries.push("" + (JSON.stringify(name)) + ": " + body);
       }
       entries = entries.join(',');
       return "module.exports=(function(module,exports){return{" + entries + "};})();";

--- a/js/test/funcster.test.js
+++ b/js/test/funcster.test.js
@@ -118,10 +118,11 @@
         var functions, script;
         functions = {
           'func_a': 'function(arg) { return arg; }',
-          'func_b': 'function(arg) { return [ arg ]; }'
+          'func_b': 'function(arg) { return [ arg ]; }',
+          'complicated -" *$@ name': 'function(arg) { return arg; }'
         };
         script = funcster._generateModuleScript(functions);
-        return assert.equal(script, 'module.exports=(function(module,exports){return{func_a: function(arg) { return arg; },func_b: function(arg) { return [ arg ]; }};})();');
+        return assert.equal(script, 'module.exports=(function(module,exports){return{"func_a": function(arg) { return arg; },"func_b": function(arg) { return [ arg ]; },"complicated -\\" *$@ name": function(arg) { return arg; }};})();');
       });
     });
     describe('_rerequire', function() {

--- a/package.json
+++ b/package.json
@@ -24,6 +24,6 @@
   },
   "devDependencies": {
     "coffee-script": "~1.6.2",
-    "mocha": "~1.8.2",
+    "mocha": "~1.8.2"
   }
 }


### PR DESCRIPTION
Funcster would not tolerate certain characters in the name of functions. This patch will escape all function names as appropriate so as to permit otherwise acceptable characters.
